### PR TITLE
UserMessageCells:messageLabel.bounds.size.height instead height calculation

### DIFF
--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/IncomingUserMessageTableViewCell.m
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/IncomingUserMessageTableViewCell.m
@@ -28,26 +28,9 @@
 // Top Margin of Date Container
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *dateContainerViewTopMargin;
 
-// Left Margin of Profile Image
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *profileImageLeftMargin;
-
-// Left Margin of Message Container
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerLeftMargin;
-
-// Profile Image Width
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *profileImageWidth;
-
 // Message Container Padding
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerLeftPadding;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerBottomPadding;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerRightPadding;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerTopPadding;
-
-// Left Margin of Message Date
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageDateLabelLeftMargin;
-
-// Right Margin of Message Date
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageDateLabelRightMargin;
 
 // Bottom Margin of Date Container
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *dateContainerBottomMargin;
@@ -265,14 +248,8 @@
 }
 
 - (CGFloat)getHeightOfViewCell {
-    NSAttributedString *fullMessage = [self buildMessage];
     
-    CGRect fullMessageRect;
-    
-    CGFloat messageLabelMaxWidth = self.frame.size.width - (self.profileImageLeftMargin.constant + self.profileImageWidth.constant + self.messageContainerLeftMargin.constant + self.messageContainerLeftPadding.constant + self.messageContainerRightPadding.constant + self.messageDateLabelLeftMargin.constant + self.messageDateLabelWidth.constant + self.messageDateLabelRightMargin.constant);
-    fullMessageRect = [fullMessage boundingRectWithSize:CGSizeMake(messageLabelMaxWidth, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil];
-    
-    CGFloat cellHeight = self.dateContainerViewTopMargin.constant + self.dateLabelContainerHeight.constant + self.dateContainerBottomMargin.constant + self.messageContainerTopPadding.constant + fullMessageRect.size.height + self.messageContainerBottomPadding.constant;
+    CGFloat cellHeight = self.dateContainerViewTopMargin.constant + self.dateLabelContainerHeight.constant + self.dateContainerBottomMargin.constant + self.messageContainerTopPadding.constant + self.messageLabel.bounds.size.height + self.messageContainerBottomPadding.constant;
     
     return cellHeight;
 }

--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/IncomingUserMessageTableViewCell.xib
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/IncomingUserMessageTableViewCell.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
@@ -117,19 +117,12 @@
                 <outlet property="dateSeperatorContainerView" destination="etk-pH-YdC" id="BCQ-UP-c9L"/>
                 <outlet property="dateSeperatorLabel" destination="te8-sc-Jve" id="iss-MS-aSt"/>
                 <outlet property="messageContainerBottomPadding" destination="Sjy-yz-TB8" id="sJR-rh-nWQ"/>
-                <outlet property="messageContainerLeftMargin" destination="aU7-lV-qKd" id="Vjy-a2-VH3"/>
-                <outlet property="messageContainerLeftPadding" destination="QOW-3C-7S8" id="xTV-fd-pyd"/>
-                <outlet property="messageContainerRightPadding" destination="TGP-2O-NAk" id="emQ-BQ-1ty"/>
                 <outlet property="messageContainerTopPadding" destination="dXr-Br-Rbw" id="BK8-vm-6Gy"/>
                 <outlet property="messageContainerView" destination="uXW-rK-eho" id="ppY-cP-Pzq"/>
                 <outlet property="messageDateLabel" destination="da1-hz-pe6" id="cxy-tm-dl2"/>
-                <outlet property="messageDateLabelLeftMargin" destination="Q8J-hr-Apx" id="Bav-Op-dlD"/>
-                <outlet property="messageDateLabelRightMargin" destination="WA7-oh-scj" id="805-fY-Dfl"/>
                 <outlet property="messageDateLabelWidth" destination="HP9-vC-J3e" id="gbM-uE-89t"/>
                 <outlet property="messageLabel" destination="sh6-y1-hH1" id="yHc-m5-hkR"/>
-                <outlet property="profileImageLeftMargin" destination="niF-WR-zOW" id="LpS-Ur-XJ4"/>
                 <outlet property="profileImageView" destination="rQm-22-hdZ" id="vOg-Yh-EXR"/>
-                <outlet property="profileImageWidth" destination="Yac-Eq-V6D" id="Q0y-xD-xgj"/>
             </connections>
             <point key="canvasLocation" x="25" y="152.5"/>
         </tableViewCell>

--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/NeutralMessageTableViewCell.m
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/NeutralMessageTableViewCell.m
@@ -22,11 +22,6 @@
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *dateContainerHeight;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *dateContainerViewBottomMargin;
 
-// For Label Width
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerViewLeftMargin;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerViewRightMargin;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerViewLeftPadding;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerViewRightPadding;
 
 @property (strong, nonatomic) SBDAdminMessage *message;
 @property (strong, nonatomic) SBDBaseMessage *prevMessage;
@@ -119,14 +114,8 @@
 
 
 - (CGFloat)getHeightOfViewCell {
-    NSAttributedString *fullMessage = [self buildMessage];
     
-    CGRect fullMessageRect;
-    
-    CGFloat messageLabelMaxWidth = self.frame.size.width - (self.messageContainerViewLeftMargin.constant + self.messageContainerViewRightMargin.constant + self.messageContainerViewLeftPadding.constant + self.messageContainerViewRightPadding.constant);
-    fullMessageRect = [fullMessage boundingRectWithSize:CGSizeMake(messageLabelMaxWidth, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil];
-    
-    CGFloat cellHeight = self.dateContainerViewTopMargin.constant + self.dateContainerHeight.constant + self.dateContainerViewBottomMargin.constant + self.messageContainerViewTopPadding.constant + self.iconImageViewHeight.constant + self.iconImageViewBottomMargin.constant + fullMessageRect.size.height + self.messageContainerViewBottomPadding.constant;
+    CGFloat cellHeight = self.dateContainerViewTopMargin.constant + self.dateContainerHeight.constant + self.dateContainerViewBottomMargin.constant + self.messageContainerViewTopPadding.constant + self.iconImageViewHeight.constant + self.iconImageViewBottomMargin.constant + self.messageLabel.bounds.size.height + self.messageContainerViewBottomPadding.constant;
     
     return cellHeight;
 }

--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/NeutralMessageTableViewCell.xib
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/NeutralMessageTableViewCell.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
@@ -103,10 +103,6 @@
                 <outlet property="iconImageViewBottomMargin" destination="xJT-kU-YUi" id="1Fn-ja-8kM"/>
                 <outlet property="iconImageViewHeight" destination="5gZ-55-dOM" id="q9C-iB-pZA"/>
                 <outlet property="messageContainerViewBottomPadding" destination="xnv-sE-N0K" id="vgk-n9-hld"/>
-                <outlet property="messageContainerViewLeftMargin" destination="4ol-al-E25" id="ahG-mC-FaN"/>
-                <outlet property="messageContainerViewLeftPadding" destination="92k-RQ-g7L" id="JSA-5b-3UT"/>
-                <outlet property="messageContainerViewRightMargin" destination="81O-Dq-YqY" id="Irp-yj-Aey"/>
-                <outlet property="messageContainerViewRightPadding" destination="4QL-EF-da0" id="m06-Bd-0Zp"/>
                 <outlet property="messageContainerViewTopPadding" destination="Tdw-c2-zIh" id="ykC-B1-6n0"/>
                 <outlet property="messageLabel" destination="tQF-su-9mm" id="nMq-0v-8ay"/>
             </connections>

--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/OutgoingUserMessageTableViewCell.m
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/OutgoingUserMessageTableViewCell.m
@@ -28,14 +28,6 @@
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerTopPadding;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerBottomPadding;
 
-// For Message Label Width
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerRightMargin;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerRightPadding;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerLeftPadding;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageContainerLeftMargin;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageDateLabelLeftMargin;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageDateLabelWidth;
-
 @property (strong, nonatomic) SBDUserMessage *message;
 @property (strong, nonatomic) SBDBaseMessage *prevMessage;
 
@@ -198,14 +190,8 @@
 }
 
 - (CGFloat)getHeightOfViewCell {
-    NSAttributedString *fullMessage = [self buildMessage];
-    CGRect fullMessageRect;
     
-    CGFloat messageLabelMaxWidth = self.frame.size.width - (self.messageContainerRightMargin.constant + self.messageContainerRightPadding.constant + self.messageContainerLeftPadding.constant + self.messageContainerLeftMargin.constant + self.messageDateLabelLeftMargin.constant + self.messageDateLabelWidth.constant);
-
-    fullMessageRect = [fullMessage boundingRectWithSize:CGSizeMake(messageLabelMaxWidth, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil];
-    
-    CGFloat cellHeight = self.dateContainerTopMargin.constant + self.dateContainerHeight.constant + self.dateContainerBottomMargin.constant + self.messageContainerTopPadding.constant + fullMessageRect.size.height + self.messageContainerBottomPadding.constant;
+    CGFloat cellHeight = self.dateContainerTopMargin.constant + self.dateContainerHeight.constant + self.dateContainerBottomMargin.constant + self.messageContainerTopPadding.constant + self.messageLabel.bounds.size.height + self.messageContainerBottomPadding.constant;
     
     return cellHeight;
 }

--- a/sample-objc/SendBird-iOS/Chatting/ViewCell/OutgoingUserMessageTableViewCell.xib
+++ b/sample-objc/SendBird-iOS/Chatting/ViewCell/OutgoingUserMessageTableViewCell.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="184"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <frame key="frameInset" width="320" height="183"/>
+                <frame key="frameInset" width="320" height="184"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yru-DR-yL3" userLabel="Date Container View">
@@ -131,15 +131,9 @@
                 <outlet property="dateSeperatorLabel" destination="Qzq-eO-w3c" id="ubX-f3-ICw"/>
                 <outlet property="deleteMessageButton" destination="Ud2-qG-Ln4" id="Eos-IF-6Jt"/>
                 <outlet property="messageContainerBottomPadding" destination="kwH-qB-1dY" id="RAg-hp-wVz"/>
-                <outlet property="messageContainerLeftMargin" destination="0kG-ca-LB9" id="G8D-aw-hDi"/>
-                <outlet property="messageContainerLeftPadding" destination="lCv-uc-7wR" id="xe6-VI-UVf"/>
-                <outlet property="messageContainerRightMargin" destination="Rp1-Yy-Lyo" id="bXj-ls-kWq"/>
-                <outlet property="messageContainerRightPadding" destination="Y0s-df-fjC" id="bTx-xe-K0G"/>
                 <outlet property="messageContainerTopPadding" destination="z6V-No-CHd" id="GAI-ke-j0i"/>
                 <outlet property="messageContainerView" destination="218-qq-guS" id="eeO-Iw-U9P"/>
                 <outlet property="messageDateLabel" destination="h0m-HV-6Ai" id="bJf-Sq-mM4"/>
-                <outlet property="messageDateLabelLeftMargin" destination="Ice-W6-rC4" id="bLH-31-Iy1"/>
-                <outlet property="messageDateLabelWidth" destination="A2u-lR-kJa" id="qSR-oI-c3e"/>
                 <outlet property="messageLabel" destination="MEf-kT-Jbd" id="G01-oc-PsZ"/>
                 <outlet property="resendMessageButton" destination="yt9-AQ-OB3" id="uQw-5c-K6G"/>
                 <outlet property="unreadCountLabel" destination="vJi-U7-1O8" id="WhK-iy-b52"/>


### PR DESCRIPTION
We don't need calculate height of text by using NSAttributedString::boundingRectWithSize: we always use setModel before getHeightOfViewCell and into setModel messageLabel already adjusts to our text, so we can just get its height.
Benefits: less dependency from outlets, which can be  missed during redesign