### PR TITLE
Make delegate var weak in ChattingView.swift to avoid memory leaks

### DIFF
--- a/sample-swift/SendBird-iOS/Chatting/ChattingView.swift
+++ b/sample-swift/SendBird-iOS/Chatting/ChattingView.swift
@@ -37,7 +37,7 @@ class ChattingView: ReusableViewFromXib, UITableViewDelegate, UITableViewDataSou
     var stopMeasuringVelocity: Bool = true
     var initialLoading: Bool = true
     
-    var delegate: (ChattingViewDelegate & MessageDelegate)?
+    weak var delegate: (ChattingViewDelegate & MessageDelegate)?
 
     @IBOutlet weak var typingIndicatorContainerViewHeight: NSLayoutConstraint!
     @IBOutlet weak var typingIndicatorImageView: UIImageView!


### PR DESCRIPTION
Hi, while using the Allocations tool I noticed that ChattingView and all of the custom tableView cells are being retained when the GroupChannelChattingViewController is dismissed. 